### PR TITLE
use module unicode flag for using unicode on dir and attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,33 @@ Reimplement luafilesystem via LuaJIT FFI.
 
 ## Docs
 
-It should be compatible with vanilla luafilesystem:
+It should be compatible with vanilla luafilesystem but with unicode paths in windows:
 http://keplerproject.github.io/luafilesystem/manual.html#reference
 
 What you only need is replacing `require('lfs')` to `require('lfs_ffi')`.`
 
+On windows `lfs.dir` iterator will provide an extra return that can be used to get `mode` and `size` attributes in a much more performant way.
+
+This is the canonical way to iterate:
+
+```Lua
+    local sep = "/"
+    for file,obj in lfs.dir(path) do
+        if file ~= "." and file ~= ".." then
+            local f = path..sep..file
+            -- obj wont be nil in windows only
+            local attr = obj and obj:attr() or lfs.attributes (f)
+            assert (type(attr) == "table",f)
+            -- do something with f and attr
+        end
+    end
+```
+
 ## Installation
 
-`[sudo] opm get spacewander/luafilesystem`
+````
+cmake -DLUAJIT_DIR="path to luajit" ../luafilesystem
+make install
+````
 
-Run `resty -e "lfs = require('lfs_ffi') print(lfs.attributes('.', 'mode'))"` to validate the installation.
+or just copy `lfs_ffi.lua` to lua folder

--- a/lfs.lua
+++ b/lfs.lua
@@ -1,0 +1,1 @@
+return require"lfs_ffi"

--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -33,6 +33,7 @@ local OS = ffi.os
 -- sys/syslimits.h
 local MAXPATH
 local MAXPATH_UNC = 32760
+local HAVE_WFINDFIRST = true
 local wchar_t
 local win_utf8_to_unicode
 local win_unicode_to_utf8
@@ -408,8 +409,9 @@ if OS == "Windows" then
         ok,findnext = pcall(function() return lib._findnext32 end)
         if not ok then findnext = lib._findnext end
 
-        wfindfirst = lib._wfindfirst
-        wfindnext = lib._wfindnext
+        ok,wfindfirst = pcall(function() return lib._wfindfirst end)
+		if not ok then HAVE_WFINDFIRST = false end
+		ok,wfindnext = pcall(function() return lib._wfindnext end)
     end
 
     local function findclose(dentry)
@@ -1283,7 +1285,7 @@ function _M.symlinkattributes(filepath, attr)
     return attributes(filepath, attr, false)
 end
 
-_M.unicode = true
+_M.unicode = HAVE_WFINDFIRST
 _M.unicode_errors = false
 --this would error with _M.unicode_errors = true
 --local cad = string.char(0xE0,0x80,0x80)--,0xFD,0xFF)

--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -397,7 +397,7 @@ if OS == "Windows" then
             );
             intptr_t _wfindfirst32(  
                 const wchar_t *filespec,  
-                struct _wfinddata32_t *fileinfo
+                struct _wfinddata_t *fileinfo
             );  
             
             int _wfindnext(  
@@ -406,7 +406,7 @@ if OS == "Windows" then
             );  
             int _wfindnext32(  
                 intptr_t handle,  
-                struct _wfinddata32_t *fileinfo   
+                struct _wfinddata_t *fileinfo   
             );  
             int _findclose(int handle);
         ]])

--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -446,6 +446,7 @@ if OS == "Windows" then
             dir._dentry.handle = findfirst(dir._pattern, entry)
             if dir._dentry.handle == -1 then
                 dir.closed = true
+                error(dir._pattern..": "..errno(),2)
                 return nil, errno()
             end
             return ffi_str(entry.name)
@@ -467,6 +468,7 @@ if OS == "Windows" then
             dir._dentry.handle = wfindfirst(szPattern, entry)
             if dir._dentry.handle == -1 then
                 dir.closed = true
+                error(dir._pattern..": "..errno(),2)
                 return nil, errno()
             end
             local szName = win_unicode_to_utf8(entry.name)--, -1, szName, 512);

--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -1239,10 +1239,10 @@ if OS == 'Windows' then
         return nil, "could not obtain link target: Function not implemented ",ENOSYS
     end
 else
-    ffi.cdef([[
-        typedef int ssize_t;
-        ssize_t readlink(const char *path, char *buf, size_t bufsize);
-    ]])
+    if jit.version_num < 20100 then
+        ffi.cdef('typedef int ssize_t;')
+    end
+    ffi.cdef('ssize_t readlink(const char *path, char *buf, size_t bufsize);')
     local EINVAL = 22
     function get_link_target_path(link_path, statbuf)
         local size = statbuf.st_size

--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -394,13 +394,20 @@ if OS == "Windows" then
             intptr_t _wfindfirst(  
             const wchar_t *filespec,  
             struct _wfinddata_t *fileinfo   
+            );
+            intptr_t _wfindfirst32(  
+                const wchar_t *filespec,  
+                struct _wfinddata32_t *fileinfo
             );  
             
             int _wfindnext(  
                 intptr_t handle,  
                 struct _wfinddata_t *fileinfo   
             );  
-            
+            int _wfindnext32(  
+                intptr_t handle,  
+                struct _wfinddata32_t *fileinfo   
+            );  
             int _findclose(int handle);
         ]])
         local ok
@@ -408,10 +415,11 @@ if OS == "Windows" then
         if not ok then findfirst = lib._findfirst end
         ok,findnext = pcall(function() return lib._findnext32 end)
         if not ok then findnext = lib._findnext end
-
         ok,wfindfirst = pcall(function() return lib._wfindfirst end)
-		if not ok then HAVE_WFINDFIRST = false end
-		ok,wfindnext = pcall(function() return lib._wfindnext end)
+        if not ok then ok,wfindfirst = pcall(function() return lib._wfindfirst32 end) end
+        if not ok then HAVE_WFINDFIRST = false end
+        ok,wfindnext = pcall(function() return lib._wfindnext end)
+        if not ok then ok,wfindnext = pcall(function() return lib._wfindnext32 end) end
     end
 
     local function findclose(dentry)

--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -451,7 +451,6 @@ if OS == "Windows" then
             dir._dentry.handle = findfirst(dir._pattern, entry)
             if dir._dentry.handle == -1 then
                 dir.closed = true
-                error(dir._pattern..": "..errno(),2)
                 return nil, errno()
             end
             return ffi_str(entry.name)
@@ -473,7 +472,6 @@ if OS == "Windows" then
             dir._dentry.handle = wfindfirst(szPattern, entry)
             if dir._dentry.handle == -1 then
                 dir.closed = true
-                error(dir._pattern..": "..errno(),2)
                 return nil, errno()
             end
             local szName = win_unicode_to_utf8(entry.name)--, -1, szName, 512);

--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -1157,6 +1157,36 @@ elseif OS == 'OSX' then
     ]])
     stat_func = lib.stat64
     lstat_func = lib.lstat64
+elseif OS == 'BSD' then
+    ffi.cdef([[
+        struct lfs_timespec {
+            time_t tv_sec;
+            long tv_nsec;
+        };
+        typedef struct {
+            uint32_t           st_dev;
+            uint32_t         st_ino;
+            uint16_t          st_mode;
+            uint16_t         st_nlink;
+            uint32_t           st_uid;
+            uint32_t           st_gid;
+            uint32_t           st_rdev;
+            struct lfs_timespec st_atimespec;
+            struct lfs_timespec st_mtimespec;
+            struct lfs_timespec st_ctimespec;
+            int64_t           st_size;
+            int64_t        st_blocks;
+            int32_t       st_blksize;
+            uint32_t        st_flags;
+            uint32_t        st_gen;
+            int32_t         st_lspare;
+            struct lfs_timespec st_birthtimespec;
+        } lfs_stat;
+        int stat(const char *path, lfs_stat *buf);
+        int lstat(const char *path, lfs_stat *buf);
+    ]])
+    stat_func = lib.stat
+    lstat_func = lib.lstat
 else
     ffi.cdef('typedef struct {} lfs_stat;')
     stat_func = function() error('TODO: support other posix system') end

--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -1239,7 +1239,10 @@ if OS == 'Windows' then
         return nil, "could not obtain link target: Function not implemented ",ENOSYS
     end
 else
-    ffi.cdef('ssize_t readlink(const char *path, char *buf, size_t bufsize);')
+    ffi.cdef([[
+        typedef int ssize_t;
+        ssize_t readlink(const char *path, char *buf, size_t bufsize);
+    ]])
     local EINVAL = 22
     function get_link_target_path(link_path, statbuf)
         local size = statbuf.st_size

--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -33,6 +33,8 @@ local OS = ffi.os
 -- sys/syslimits.h
 local MAXPATH
 local wchar_t
+local win_utf8_to_unicode
+local win_unicode_to_utf8
 if OS == 'Windows' then
     MAXPATH = 260
     ffi.cdef([[
@@ -119,7 +121,41 @@ if OS == "Windows" then
         int _fileno(struct FILE *stream);
         int _setmode(int fd, int mode);
     ]])
+	
+	ffi.cdef([[
 
+	size_t wcslen(const wchar_t *str);
+	wchar_t *wcsncpy(wchar_t *strDest, const wchar_t *strSource, size_t count);
+	
+	int WideCharToMultiByte(
+		unsigned int     CodePage,
+		DWORD    dwFlags,
+		const wchar_t*  lpWideCharStr,
+		int      cchWideChar,
+		char*    lpMultiByteStr,
+		int      cbMultiByte,
+		const char*   lpDefaultChar,
+		int*   lpUsedDefaultChar);
+	
+	int MultiByteToWideChar(
+		unsigned int     CodePage,
+		DWORD    dwFlags,
+		const char*   lpMultiByteStr,
+		int      cbMultiByte,
+		wchar_t*   lpWideCharStr,
+		int      cchWideChar);
+	
+	]])
+	
+	local CP_UTF8 = 65001
+	function win_utf8_to_unicode(szUtf8, szUnicode, nLenWchar)
+		return lib.MultiByteToWideChar(CP_UTF8, 0, szUtf8, -1, szUnicode, nLenWchar);
+	end
+	
+	function win_unicode_to_utf8( szUnicode,  nLenWchar, szUtf8,  nLen)
+		return lib.WideCharToMultiByte(CP_UTF8, 0, szUnicode, nLenWchar, szUtf8, nLen, nil, nil);
+	end
+	
     function _M.chdir(path)
         if type(path) ~= 'string' then
             error('path should be a string')
@@ -215,6 +251,8 @@ if OS == "Windows" then
 
     local findfirst
     local findnext
+	local wfindfirst
+	local wfindnext
     if IS_64_BIT then
         ffi.cdef([[
             typedef struct _finddata64_t {
@@ -243,10 +281,38 @@ if OS == "Windows" then
             } _finddata_t;
             int _findfirst32(const char* filespec, _finddata_t* fileinfo);
             int _findnext32(int handle, _finddata_t *fileinfo);
+			
+			int _findfirst(const char* filespec, _finddata_t* fileinfo);
+            int _findnext(int handle, _finddata_t *fileinfo);
+			
+			typedef struct _wfinddata_t {
+                uint32_t  attrib;
+                uint32_t  time_create;
+                uint32_t  time_access;
+                uint32_t  time_write;
+                uint32_t  size;
+                wchar_t      name[]] .. MAXPATH ..[[];
+            } _wfinddata_t;
+			intptr_t _wfindfirst(  
+			const wchar_t *filespec,  
+			struct _wfinddata_t *fileinfo   
+			);  
+			
+			int _wfindnext(  
+				intptr_t handle,  
+				struct _wfinddata_t *fileinfo   
+			);  
+			
             int _findclose(int handle);
         ]])
-        findfirst = lib._findfirst32
-        findnext = lib._findnext32
+		local ok
+		ok,findfirst = pcall(function() return lib._findfirst32 end)
+		if not ok then findfirst = lib._findfirst end
+		ok,findnext = pcall(function() return lib._findnext32 end)
+		if not ok then findnext = lib._findnext end
+
+        wfindfirst = lib._wfindfirst
+        wfindnext = lib._wfindnext
     end
 
     local function findclose(dentry)
@@ -284,13 +350,39 @@ if OS == "Windows" then
         close(dir)
         return nil
     end
+	
+    local function witerator(dir)
+        if dir.closed ~= false then error("closed directory") end
+        local entry = ffi.new("_wfinddata_t")
+        if not dir._dentry then
+            dir._dentry = ffi.new(dir_type)
+			local szPattern = ffi.new("wchar_t[?]",256)
+			win_utf8_to_unicode(dir._pattern, szPattern, 256);
+            dir._dentry.handle = wfindfirst(szPattern, entry)
+            if dir._dentry.handle == -1 then
+                dir.closed = true
+                return nil, errno()
+            end
+			local szName = ffi.new("char[?]",512)
+			win_unicode_to_utf8(entry.name, -1, szName, 512);
+            return ffi_str(szName)
+        end
+
+        if wfindnext(dir._dentry.handle, entry) == 0 then
+			local szName = ffi.new("char[?]",512)
+			win_unicode_to_utf8(entry.name, -1, szName, 512);
+            return ffi_str(szName)
+        end
+        close(dir)
+        return nil
+    end
 
     local dirmeta = {__index = {
         next = iterator,
         close = close,
     }}
 
-    function _M.dir(path)
+    function _M.sdir(path)
         if #path > MAXPATH - 2 then
             error('path too long: ' .. path)
         end
@@ -300,7 +392,31 @@ if OS == "Windows" then
         }, dirmeta)
         return iterator, dir_obj
     end
+	
+	local wdirmeta = {__index = {
+        next = witerator,
+        close = close,
+    }}
 
+    function _M.wdir(path)
+        if #path > MAXPATH - 2 then
+            error('path too long: ' .. path)
+        end
+        local dir_obj = setmetatable({
+            _pattern = path..'/*',
+            closed  = false,
+        }, wdirmeta)
+        return witerator, dir_obj
+    end
+	
+	function _M.dir(path)
+		if _M.unicode then
+			return _M.wdir(path)
+		else
+			return _M.sdir(path)
+		end
+	end
+	
     ffi.cdef([[
         int _fileno(struct FILE *stream);
         int fseek(struct FILE *stream, long offset, int origin);
@@ -885,9 +1001,19 @@ elseif OS == 'Windows' then
             long long           st_ctime;
         } stat;
         int _stat64i32(const char *path, stat *buffer);
+		int _stat(const char *path, stat *buffer);
+		int _wstat(const wchar_t *path, stat *buffer);  
     ]])
 
-    stat_func = lib._stat64i32
+	stat_func = function(filepath, buf)
+		if _M.unicode then
+			local szfp = ffi.new("wchar_t[?]",256)
+			win_utf8_to_unicode(filepath, szfp, 256);
+			return lib._wstat(szfp, buf)
+		else
+			return lib._stat(filepath, buf)
+		end
+    end
     lstat_func = stat_func
 elseif OS == 'OSX' then
     ffi.cdef([[

--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -121,41 +121,41 @@ if OS == "Windows" then
         int _fileno(struct FILE *stream);
         int _setmode(int fd, int mode);
     ]])
-	
-	ffi.cdef([[
+    
+    ffi.cdef([[
 
-	size_t wcslen(const wchar_t *str);
-	wchar_t *wcsncpy(wchar_t *strDest, const wchar_t *strSource, size_t count);
-	
-	int WideCharToMultiByte(
-		unsigned int     CodePage,
-		DWORD    dwFlags,
-		const wchar_t*  lpWideCharStr,
-		int      cchWideChar,
-		char*    lpMultiByteStr,
-		int      cbMultiByte,
-		const char*   lpDefaultChar,
-		int*   lpUsedDefaultChar);
-	
-	int MultiByteToWideChar(
-		unsigned int     CodePage,
-		DWORD    dwFlags,
-		const char*   lpMultiByteStr,
-		int      cbMultiByte,
-		wchar_t*   lpWideCharStr,
-		int      cchWideChar);
-	
-	]])
-	
-	local CP_UTF8 = 65001
-	function win_utf8_to_unicode(szUtf8, szUnicode, nLenWchar)
-		return lib.MultiByteToWideChar(CP_UTF8, 0, szUtf8, -1, szUnicode, nLenWchar);
-	end
-	
-	function win_unicode_to_utf8( szUnicode,  nLenWchar, szUtf8,  nLen)
-		return lib.WideCharToMultiByte(CP_UTF8, 0, szUnicode, nLenWchar, szUtf8, nLen, nil, nil);
-	end
-	
+    size_t wcslen(const wchar_t *str);
+    wchar_t *wcsncpy(wchar_t *strDest, const wchar_t *strSource, size_t count);
+    
+    int WideCharToMultiByte(
+        unsigned int     CodePage,
+        DWORD    dwFlags,
+        const wchar_t*  lpWideCharStr,
+        int      cchWideChar,
+        char*    lpMultiByteStr,
+        int      cbMultiByte,
+        const char*   lpDefaultChar,
+        int*   lpUsedDefaultChar);
+    
+    int MultiByteToWideChar(
+        unsigned int     CodePage,
+        DWORD    dwFlags,
+        const char*   lpMultiByteStr,
+        int      cbMultiByte,
+        wchar_t*   lpWideCharStr,
+        int      cchWideChar);
+    
+    ]])
+    
+    local CP_UTF8 = 65001
+    function win_utf8_to_unicode(szUtf8, szUnicode, nLenWchar)
+        return lib.MultiByteToWideChar(CP_UTF8, 0, szUtf8, -1, szUnicode, nLenWchar);
+    end
+    
+    function win_unicode_to_utf8( szUnicode,  nLenWchar, szUtf8,  nLen)
+        return lib.WideCharToMultiByte(CP_UTF8, 0, szUnicode, nLenWchar, szUtf8, nLen, nil, nil);
+    end
+    
     function _M.chdir(path)
         if type(path) ~= 'string' then
             error('path should be a string')
@@ -251,8 +251,8 @@ if OS == "Windows" then
 
     local findfirst
     local findnext
-	local wfindfirst
-	local wfindnext
+    local wfindfirst
+    local wfindnext
     if IS_64_BIT then
         ffi.cdef([[
             typedef struct _finddata64_t {
@@ -281,11 +281,11 @@ if OS == "Windows" then
             } _finddata_t;
             int _findfirst32(const char* filespec, _finddata_t* fileinfo);
             int _findnext32(int handle, _finddata_t *fileinfo);
-			
-			int _findfirst(const char* filespec, _finddata_t* fileinfo);
+            
+            int _findfirst(const char* filespec, _finddata_t* fileinfo);
             int _findnext(int handle, _finddata_t *fileinfo);
-			
-			typedef struct _wfinddata_t {
+            
+            typedef struct _wfinddata_t {
                 uint32_t  attrib;
                 uint32_t  time_create;
                 uint32_t  time_access;
@@ -293,23 +293,23 @@ if OS == "Windows" then
                 uint32_t  size;
                 wchar_t      name[]] .. MAXPATH ..[[];
             } _wfinddata_t;
-			intptr_t _wfindfirst(  
-			const wchar_t *filespec,  
-			struct _wfinddata_t *fileinfo   
-			);  
-			
-			int _wfindnext(  
-				intptr_t handle,  
-				struct _wfinddata_t *fileinfo   
-			);  
-			
+            intptr_t _wfindfirst(  
+            const wchar_t *filespec,  
+            struct _wfinddata_t *fileinfo   
+            );  
+            
+            int _wfindnext(  
+                intptr_t handle,  
+                struct _wfinddata_t *fileinfo   
+            );  
+            
             int _findclose(int handle);
         ]])
-		local ok
-		ok,findfirst = pcall(function() return lib._findfirst32 end)
-		if not ok then findfirst = lib._findfirst end
-		ok,findnext = pcall(function() return lib._findnext32 end)
-		if not ok then findnext = lib._findnext end
+        local ok
+        ok,findfirst = pcall(function() return lib._findfirst32 end)
+        if not ok then findfirst = lib._findfirst end
+        ok,findnext = pcall(function() return lib._findnext32 end)
+        if not ok then findnext = lib._findnext end
 
         wfindfirst = lib._wfindfirst
         wfindnext = lib._wfindnext
@@ -350,27 +350,27 @@ if OS == "Windows" then
         close(dir)
         return nil
     end
-	
+    
     local function witerator(dir)
         if dir.closed ~= false then error("closed directory") end
         local entry = ffi.new("_wfinddata_t")
         if not dir._dentry then
             dir._dentry = ffi.new(dir_type)
-			local szPattern = ffi.new("wchar_t[?]",256)
-			win_utf8_to_unicode(dir._pattern, szPattern, 256);
+            local szPattern = ffi.new("wchar_t[?]",256)
+            win_utf8_to_unicode(dir._pattern, szPattern, 256);
             dir._dentry.handle = wfindfirst(szPattern, entry)
             if dir._dentry.handle == -1 then
                 dir.closed = true
                 return nil, errno()
             end
-			local szName = ffi.new("char[?]",512)
-			win_unicode_to_utf8(entry.name, -1, szName, 512);
+            local szName = ffi.new("char[?]",512)
+            win_unicode_to_utf8(entry.name, -1, szName, 512);
             return ffi_str(szName)
         end
 
         if wfindnext(dir._dentry.handle, entry) == 0 then
-			local szName = ffi.new("char[?]",512)
-			win_unicode_to_utf8(entry.name, -1, szName, 512);
+            local szName = ffi.new("char[?]",512)
+            win_unicode_to_utf8(entry.name, -1, szName, 512);
             return ffi_str(szName)
         end
         close(dir)
@@ -392,8 +392,8 @@ if OS == "Windows" then
         }, dirmeta)
         return iterator, dir_obj
     end
-	
-	local wdirmeta = {__index = {
+    
+    local wdirmeta = {__index = {
         next = witerator,
         close = close,
     }}
@@ -408,15 +408,15 @@ if OS == "Windows" then
         }, wdirmeta)
         return witerator, dir_obj
     end
-	
-	function _M.dir(path)
-		if _M.unicode then
-			return _M.wdir(path)
-		else
-			return _M.sdir(path)
-		end
-	end
-	
+    
+    function _M.dir(path)
+        if _M.unicode then
+            return _M.wdir(path)
+        else
+            return _M.sdir(path)
+        end
+    end
+    
     ffi.cdef([[
         int _fileno(struct FILE *stream);
         int fseek(struct FILE *stream, long offset, int origin);
@@ -656,11 +656,11 @@ else
     else
         flock_def = [[
             struct flock {
-                int64_t	l_start;
-                int64_t	l_len;
-                int32_t	l_pid;
-                short	l_type;
-                short	l_whence;
+                int64_t l_start;
+                int64_t l_len;
+                int32_t l_pid;
+                short   l_type;
+                short   l_whence;
             };
         ]]
         mode_ltype_map = {
@@ -1001,18 +1001,18 @@ elseif OS == 'Windows' then
             long long           st_ctime;
         } stat;
         int _stat64i32(const char *path, stat *buffer);
-		int _stat(const char *path, stat *buffer);
-		int _wstat(const wchar_t *path, stat *buffer);  
+        int _stat(const char *path, stat *buffer);
+        int _wstat(const wchar_t *path, stat *buffer);  
     ]])
 
-	stat_func = function(filepath, buf)
-		if _M.unicode then
-			local szfp = ffi.new("wchar_t[?]",256)
-			win_utf8_to_unicode(filepath, szfp, 256);
-			return lib._wstat(szfp, buf)
-		else
-			return lib._stat(filepath, buf)
-		end
+    stat_func = function(filepath, buf)
+        if _M.unicode then
+            local szfp = ffi.new("wchar_t[?]",256)
+            win_utf8_to_unicode(filepath, szfp, 256);
+            return lib._wstat(szfp, buf)
+        else
+            return lib._stat(filepath, buf)
+        end
     end
     lstat_func = stat_func
 elseif OS == 'OSX' then

--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -152,8 +152,6 @@ if OS == "Windows" then
     
     ]])
     ffi.cdef[[
-        static const int FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
-        static const int FORMAT_MESSAGE_IGNORE_INSERTS = 0x00000200;
         
         uint32_t GetLastError();
         uint32_t FormatMessageA(
@@ -170,8 +168,10 @@ if OS == "Windows" then
     local function error_win(lvl)
         local errcode = ffi.C.GetLastError()
         local str = ffi.new("char[?]",1024)
-        local numout = ffi.C.FormatMessageA(bit.bor(ffi.C.FORMAT_MESSAGE_FROM_SYSTEM,
-            ffi.C.FORMAT_MESSAGE_IGNORE_INSERTS), nil, errcode, 0, str, 1023, nil)
+        local FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
+        local FORMAT_MESSAGE_IGNORE_INSERTS = 0x00000200;
+        local numout = ffi.C.FormatMessageA(bit.bor(FORMAT_MESSAGE_FROM_SYSTEM,
+            FORMAT_MESSAGE_IGNORE_INSERTS), nil, errcode, 0, str, 1023, nil)
         if numout == 0 then
             error("Windows Error: (Error calling FormatMessage)", lvl)
         else
@@ -1283,5 +1283,8 @@ function _M.symlinkattributes(filepath, attr)
 end
 
 _M.unicode = true
+_M.unicode_errors = false
+--this would error with _M.unicode_errors = true
+--local cad = string.char(0xE0,0x80,0x80)--,0xFD,0xFF)
 
 return _M

--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -21,6 +21,11 @@ local _M = {
 local IS_64_BIT = ffi.abi('64bit')
 local ERANGE = 'Result too large'
 
+if not pcall(ffi.typeof, "ssize_t") then
+    -- LuaJIT 2.0 doesn't have ssize_t as a builtin type, let's define it
+    ffi.cdef("typedef intptr_t ssize_t")
+end
+
 ffi.cdef([[
     char* strerror(int errnum);
 ]])
@@ -1239,9 +1244,7 @@ if OS == 'Windows' then
         return nil, "could not obtain link target: Function not implemented ",ENOSYS
     end
 else
-    if jit.version_num < 20100 then
-        ffi.cdef('typedef int ssize_t;')
-    end
+
     ffi.cdef('ssize_t readlink(const char *path, char *buf, size_t bufsize);')
     local EINVAL = 22
     function get_link_target_path(link_path, statbuf)

--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -1231,13 +1231,14 @@ if OS == 'Windows' then
         return nil
     end
 else
-    ffi.cdef('unsigned long readlink(const char *path, char *buf, size_t bufsize);')
+    ffi.cdef('ssize_t readlink(const char *path, char *buf, size_t bufsize);')
     function get_link_target_path(link_path)
         local size = MAXPATH
         while true do
             local buf = ffi.new('char[?]', size)
             local read = lib.readlink(link_path, buf, size)
             if read == -1 then
+                error(errno(),2)
                 return nil, errno()
             end
             if read < size then

--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -348,9 +348,9 @@ if OS == "Windows" then
                 uint64_t  size;
                 char      name[]] .. MAXPATH ..[[];
             } _finddata_t;
-            int _findfirst64(const char *filespec, _finddata_t *fileinfo);
-            int _findnext64(int handle, _finddata_t *fileinfo);
-            int _findclose(int handle);
+            intptr_t _findfirst64(const char *filespec, _finddata_t *fileinfo);
+            int _findnext64(intptr_t handle, _finddata_t *fileinfo);
+            int _findclose(intptr_t handle);
             typedef struct _wfinddata_t { //is _wfinddata64_t
                 uint64_t  attrib;
                 uint64_t  time_create;
@@ -377,11 +377,11 @@ if OS == "Windows" then
                 uint32_t  size;
                 char      name[]] .. MAXPATH ..[[];
             } _finddata_t;
-            int _findfirst32(const char* filespec, _finddata_t* fileinfo);
-            int _findnext32(int handle, _finddata_t *fileinfo);
+            intptr_t _findfirst32(const char* filespec, _finddata_t* fileinfo);
+            int _findnext32(intptr_t handle, _finddata_t *fileinfo);
             
-            int _findfirst(const char* filespec, _finddata_t* fileinfo);
-            int _findnext(int handle, _finddata_t *fileinfo);
+            intptr_t _findfirst(const char* filespec, _finddata_t* fileinfo);
+            int _findnext(intptr_t handle, _finddata_t *fileinfo);
             
             typedef struct _wfinddata_t {
                 uint32_t  attrib;
@@ -408,7 +408,7 @@ if OS == "Windows" then
                 intptr_t handle,  
                 struct _wfinddata_t *fileinfo   
             );  
-            int _findclose(int handle);
+            int _findclose(intptr_t handle);
         ]])
         local ok
         ok,findfirst = pcall(function() return lib._findfirst32 end)
@@ -429,7 +429,7 @@ if OS == "Windows" then
         end
     end
 
-    local dir_type = ffi.metatype("struct {int handle;}", {
+    local dir_type = ffi.metatype("struct {intptr_t handle;}", {
         __gc = findclose
     })
 

--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -106,7 +106,7 @@ if OS == "Windows" then
                 time_t modtime;
             };
             typedef struct __utimebuf32 utimebuf;
-            int _utime632(unsigned char *file, utimebuf *times);
+            int _utime32(unsigned char *file, utimebuf *times);
         ]]
     end
 


### PR DESCRIPTION
local lfs = require"lfs_ffi"
lfs.unicode = true
for file in lfs.dir([[c:/luaGL/frames_anima/luajit_test/]]) do print(file);print(file:byte(1,#file)) end

things left mkdir, chdir ,set correct MAX_PATH and do winx64 also

Also corrected a problem when compiling with mingw64 (32 bits) where _findfirst32 is exported as _findfirst
Solution was trying with pcall 

Appveyor test is failing for x64 but I only changed x32