### PR TITLE
Fix an LFS FFI bug on arm64 architectures

### DIFF
--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -591,7 +591,7 @@ if OS == 'Linux' then
         -- On arm64 stat and lstat do not exist as syscall, so use newfstatat instead
         -- int newfstatat(int dirfd, const char *filename, struct stat *statbuf, int flags)
         stat_func = function(filepath, buf)
-            return lib.syscall(79, int(STAT._AT_FDCWD), filepath, buf, 0)
+            return lib.syscall(79, int(STAT._AT_FDCWD), filepath, buf, int(0))
         end
         lstat_func = function(filepath, buf)
             return lib.syscall(79, int(STAT._AT_FDCWD), filepath, buf, int(STAT._AT_SYMLINK_NOFOLLOW))


### PR DESCRIPTION
The bare 0 in the direct stat sycall seems to be getting passed through LuaJIT's variadic arg handling incorrectly on arm64. When syscall() is declared as long syscall(long number, ...), variadic arguments that are plain Lua numbers get promoted to double [per C variadic promotion rules](https://luajit.org/ext_ffi_semantics.html) as interpreted by LuaJIT. On arm64, floating-point args go in different registers than integer args, so the kernel sees garbage in the integer register where it expects flags.

Below's a reproduction script:
```
--
-- Reproducer for arm64 newfstatat EINVAL bug in lfs_ffi.
--
-- On arm64 Linux, the `stat` syscall doesn't exist; glibc uses `newfstatat`
-- (syscall 79) instead. The lfs_ffi library passes the flags argument as a
-- bare Lua `0` through LuaJIT's variadic FFI call to syscall(), which causes
-- it to be passed in the wrong register (float vs int), resulting in EINVAL.
--
-- Usage:
--   luajit test-stat-arm64.lua /some/path
--
-- With strace:
--   strace -e trace=newfstatat,stat luajit test-stat-arm64.lua /some/path
--
local ffi = require "ffi"
local bit = require "bit"
local int = ffi.typeof("int")
ffi.cdef([[
    long syscall(long number, ...);
]])
local arch = ffi.arch
local os_name = ffi.os
if os_name ~= "Linux" then
    print("This reproducer is Linux-only (got: " .. os_name .. ")")
    os.exit(1)
end
if arch ~= "arm64" then
    print("WARNING: This reproducer targets arm64 but running on: " .. arch)
    print("The bug may not manifest on this architecture.\n")
end
-- arm64 stat struct layout
ffi.cdef([[
    typedef struct {
        unsigned long   st_dev;
        unsigned long   st_ino;
        unsigned int    st_mode;
        unsigned int    st_nlink;
        unsigned int    st_uid;
        unsigned int    st_gid;
        unsigned long   st_rdev;
        unsigned long   __pad1;
        long            st_size;
        int             st_blksize;
        int             __pad2;
        long            st_blocks;
        long            st_atime;
        unsigned long   st_atime_nsec;
        long            st_mtime;
        unsigned long   st_mtime_nsec;
        long            st_ctime;
        unsigned long   st_ctime_nsec;
        unsigned int    __unused4;
        unsigned int    __unused5;
    } test_stat;
]])
local AT_FDCWD = -0x64
local path = arg[1] or "."
print("Path: " .. path)
print("Arch: " .. arch)
print("")
-- Buggy version: bare 0 as flags (reproduces the EINVAL on arm64)
local function stat_buggy(filepath)
    local buf = ffi.new("test_stat")
    local ret = ffi.C.syscall(79, int(AT_FDCWD), filepath, buf, 0)
    return ret, ffi.errno()
end
-- Fixed version: int(0) as flags
local function stat_fixed(filepath)
    local buf = ffi.new("test_stat")
    local ret = ffi.C.syscall(79, int(AT_FDCWD), filepath, buf, int(0))
    return ret, ffi.errno()
end
local iterations = tonumber(arg[2]) or 200
print("Iterations: " .. iterations)
print("(LuaJIT compiles traces after ~56 loop iterations by default)")
print("")
print("--- Buggy call (bare 0 for flags) ---")
local buggy_failures = 0
for i = 1, iterations do
    local ret, errno = stat_buggy(path)
    if ret ~= 0 then
        buggy_failures = buggy_failures + 1
        if buggy_failures == 1 then
            print(string.format("  First failure at iteration %d (errno=%d)", i, errno))
            if errno == 22 then
                print("  -> EINVAL: Invalid argument (this is the bug!)")
            end
        end
    end
end
if buggy_failures == 0 then
    print("Result: all passed (bug did not manifest)")
else
    print(string.format("Result: %d/%d calls FAILED", buggy_failures, iterations))
end
print("")
print("--- Fixed call (int(0) for flags) ---")
local fixed_failures = 0
for i = 1, iterations do
    local ret, errno = stat_fixed(path)
    if ret ~= 0 then
        fixed_failures = fixed_failures + 1
        if fixed_failures == 1 then
            print(string.format("  First failure at iteration %d (errno=%d)", i, errno))
        end
    end
end
if fixed_failures == 0 then
    print("Result: all passed")
else
    print(string.format("Result: %d/%d calls FAILED", fixed_failures, iterations))
end
```

The call which doesn't have the 0 wrapped in int() should start failing after 50+ iterations. The patched call should never fail.

Example output on an arm64 server:
```
$ luajit test.lua .
Path: .
Arch: arm64

Iterations: 200
(LuaJIT compiles traces after ~56 loop iterations by default)

--- Buggy call (bare 0 for flags) ---
  First failure at iteration 58 (errno=22)
  -> EINVAL: Invalid argument (this is the bug!)
Result: 142/200 calls FAILED

--- Fixed call (int(0) for flags) ---
Result: all passed
```